### PR TITLE
fix: filedrop crash due number of arguments passed to Dropped.__init__

### DIFF
--- a/textual_filedrop/_filedrop.py
+++ b/textual_filedrop/_filedrop.py
@@ -113,7 +113,6 @@ class FileDrop(Widget, can_focus=True, can_focus_children=False):
                 filepaths,
                 filenames,
                 filesobj,
-                oneline,
             )
         )
         self.txt = oneline


### PR DESCRIPTION
Resolves #2.
